### PR TITLE
Fix Ansible environment variable lookup

### DIFF
--- a/provisioning/dev/init.yml
+++ b/provisioning/dev/init.yml
@@ -46,7 +46,7 @@
           path: "{{ playbook_dir }}"
 
     - name: Get user's current UID
-      command: "id -u {{ lookup('ENV', 'USER') }}"
+      command: "id -u {{ lookup('env', 'USER') }}"
       register: id
       when: id is undefined
 


### PR DESCRIPTION
Similar fix to Ansible environment variable lookup as the website WSL2-support pull request ('ENV' -> 'env')
