### PR TITLE
ci: Scope the compile push trigger and declare token permissions

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -2,6 +2,10 @@
 name: 'Auto Assign PRs'
 on: pull_request
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   add-reviewers:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -5,6 +5,9 @@ on:
     # Runs 6am on Mondays (see https://crontab.guru)
     - cron: '0 6 * * 1'
   workflow_dispatch:
+permissions:
+  contents: read
+
 jobs:
   build-docker-images:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,6 +20,11 @@ on:
   schedule:
     - cron: '0 10 * * 6'
 
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -3,6 +3,9 @@ name: Build & Deploy Production
 on:
   push:
     branches: [master]
+permissions:
+  contents: read
+
 jobs:
   build-docker-images:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches: [dev]
   pull_request:
+permissions:
+  contents: read
+
 jobs:
   eslint:
     name: ESLint

--- a/.github/workflows/ts-compile.yml
+++ b/.github/workflows/ts-compile.yml
@@ -2,7 +2,11 @@
 name: Typescript Compile
 on:
   push:
+    branches: [dev]
   pull_request:
+permissions:
+  contents: read
+
 jobs:
   typescript-compile:
     name: Typescript Compile


### PR DESCRIPTION
Part of standardising GitHub settings across the repos. This is the code half; the settings half is applied directly.

**`Typescript Compile` had no branch filter on its push trigger**, so every push to any branch ran it a second time alongside the `pull_request` run. Scoped to `dev`, matching `eslint.yml` in this repo. (The API repo had the same problem on both workflows plus an unnamed ESLint job; that is handled separately.)

**Token permissions are now declared per workflow.** The repository default for `GITHUB_TOKEN` is `write`, which is more than anything here needs:

| Workflow | Permissions | Why |
|---|---|---|
| ESLint, Typescript Compile | `contents: read` | checkout only |
| Build base image, Deploy Production | `contents: read` | authenticate to Docker Hub with their own secrets |
| Auto Assign PRs | `+ pull-requests: write` | assigns reviewers |
| CodeQL | `actions: read`, `contents: read`, `security-events: write` | uploads analysis results; already declared these at job level, now stated at workflow level too |

## Validation

All six workflow files parse as YAML and resolve to the permissions above. ESLint, Typescript Compile, CodeQL and Auto Assign all run on this PR, so every write-needing path is exercised here.

Once this merges, the default token permission drops to read-only. `ESLint` and `Typescript Compile` are already required on `dev` via a branch ruleset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)